### PR TITLE
docs(add support for query string parsing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ An in-memory web api for Angular 2 demos and tests.
 See usage in the Angular.io
 [Server Communication](https://angular.io/docs/ts/latest/guide/server-communication.html) chapter.
 
+# Simple Query String Support
+Custom filters can be passed as a regex pattern via query string. 
+The query string defines which property and value to match against.
+
+Format: `/app/heroes/?propertyName=regexPattern`
+
+In the following example we are matching on all names containing the letter 'j' in the heroes collection.
+
+`/app/heroes/?name=j+`
+
 # To Do
 * add  documentation
 * add tests (shameful omission!)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-in-memory-web-api",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "An in-memory web api for demos and tests",
   "main":"index.js",
   "jsnext:main": "esm/index.js",


### PR DESCRIPTION
@wardbell 
I have added a simple query string parser to the in mem api.

This will allow us to implement a type to search box for the TOH Http chapter.

The existing api remains unchanged, but I added the ability to pass a regex pattern in a query string param.

Ex:
``` app/heroes/?name=magn+ or app/heroes?name=magn+  ```

In this example I am filtering based on regex matches in the 'name' column. 

Both the column name and the pattern value are dynamic, so you can search based on arbitrary column names and regex patterns. 
 