### PR TITLE
Fix query example and clarify about case insensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The query string defines which property and value to match against.
 
 Format: `/app/heroes/?propertyName=regexPattern`
 
-In the following example we are matching on all names containing the letter 'j' in the heroes collection.
+Note that pattern matches are case insensitive.
+The following example will match all heroes with a name containing the letter `j` or `J`:
 
-`/app/heroes/?name=j+`
+`/app/heroes/?name=j`
 
 # To Do
 * add  documentation


### PR DESCRIPTION
The `+` in the example is at best unnecessary for the regex to match; also, as part of a query parameter, a `+` can get interpreted as a space (see [HTML 4.01 section 17.13.4](https://www.w3.org/TR/REC-html40/interact/forms.html#h-17.13.4)) when eventually dealing with a real server (and that is not the behavior we want to illustrate in that example).