### PR TITLE
fix: make in-memory-web-api AOT compilation friendly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,17 +2,4 @@ export * from './http-status-codes';
 export * from './in-memory-backend.service';
 import { ModuleWithProviders, Type } from '@angular/core';
 import { InMemoryBackendConfigArgs, InMemoryDbService } from './in-memory-backend.service';
-export declare class InMemoryWebApiModule {
-    /**
-    *  Prepare in-memory-web-api in the root/boot application module
-    *  with class that implements InMemoryDbService and creates an in-memory database.
-    *
-    * @param {Type} dbCreator - Class that creates seed data for in-memory database. Must implement InMemoryDbService.
-    * @param {InMemoryBackendConfigArgs} [options]
-    *
-    * @example
-    * InMemoryWebApiModule.forRoot(dbCreator);
-    * InMemoryWebApiModule.forRoot(dbCreator, {useValue: {delay:600}});
-    */
-    static forRoot(dbCreator: Type<InMemoryDbService>, options?: InMemoryBackendConfigArgs): ModuleWithProviders;
-}
+export { InMemoryWebApiModule } from './src/index';

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "zone.js": "^0.6.23"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.7",
-    "@angular/compiler": "2.0.0-rc.7",
-    "@angular/core": "2.0.0-rc.7",
-    "@angular/http": "2.0.0-rc.7",
-    "@angular/platform-browser": "2.0.0-rc.7",
+    "@angular/common": "2.0.0",
+    "@angular/compiler": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/http": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.21",

--- a/src/in-memory-backend.service.ts
+++ b/src/in-memory-backend.service.ts
@@ -8,16 +8,10 @@ import 'rxjs/add/operator/delay';
 import { STATUS, STATUS_CODE_INFO } from './http-status-codes';
 
 /**
-* Class that creates seed data for in-memory database
-* Must implement InMemoryDbService.
-*/
-export const SEED_DATA = new OpaqueToken('seedData');
-
-/**
 * Interface for a class that creates an in-memory database
 * Safe for consuming service to morph arrays and objects.
 */
-export interface InMemoryDbService {
+export abstract class InMemoryDbService {
   /**
   * Creates "database" object hash whose keys are collection names
   * and whose values are arrays of the collection objects.
@@ -26,7 +20,7 @@ export interface InMemoryDbService {
   * This condition allows InMemoryBackendService to morph the arrays and objects
   * without touching the original source data.
   */
-  createDb(): {};
+  abstract createDb(): {};
 }
 
 /**
@@ -123,7 +117,7 @@ export class InMemoryBackendService {
   protected db: {};
 
   constructor(
-    @Inject(SEED_DATA) private seedData: InMemoryDbService,
+    private seedData: InMemoryDbService,
     @Inject(InMemoryBackendConfig) @Optional() config: InMemoryBackendConfigArgs) {
     this.resetDb();
 


### PR DESCRIPTION
**Supeseded by PR #31**

Should close as soon as we know that #31 has the goods.

@wardbell 
This is a WIP.

It appears to be working, but there is one minor issue with the way the index.d.ts barrel is generated.

For some reason it is generated as 
```
export declare class InMemoryWebApiModule {
  /**
    *  Prepare in-memory-web-api in the root/boot application module
    *  with class that implements InMemoryDbService and creates an in-memory database.
    *
    * @param {Type} dbCreator - Class that creates seed data for in-memory database. Must implement InMemoryDbService.
    * @param {InMemoryBackendConfigArgs} [options]
    *
    * @example
    * InMemoryWebApiModule.forRoot(dbCreator);
    * InMemoryWebApiModule.forRoot(dbCreator, {useValue: {delay:600}});
    */
    static forRoot(dbCreator: Type, options?: InMemoryBackendConfigArgs): ModuleWithProviders;
}
```
Instead of just `export * from ./src/index`

The declaration of the class instead of exporting the symbol from src breaks aot compilation. Manually updating it to export fixes it, but how do we do this via the build? 