### PR TITLE
chore(deps): remove reflect-metadata, zone

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
-    "reflect-metadata": "~0.1.8",
-    "rxjs": "^5.0.1",
-    "zone.js": "^0.7.4"
+    "rxjs": "^5.0.1"
   },
   "devDependencies": {
     "@angular/common": "~2.4.0",
@@ -63,7 +61,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "lite-server": "^2.2.2",
     "lodash": "^4.16.2",
-    "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.4",
     "rollup": "^0.36.0",
     "rollup-stream": "^1.14.0",


### PR DESCRIPTION
`angular-in-memory-web-api` itself does not depend on neither of these packages to function.

Rather, `@angular/*` depends on them instead.

/cc @wardbell @Foxandxss 