### PR TITLE
Use double equals when comparing IDs of different types

### DIFF
--- a/src/in-memory-backend.service.ts
+++ b/src/in-memory-backend.service.ts
@@ -651,7 +651,7 @@ export class InMemoryBackendService {
     if (item.id == undefined) {
       return createErrorResponse(req, STATUS.NOT_FOUND, `Missing '${collectionName}' id`);
     }
-    if (id !== item.id) {
+    if (id != item.id) {
       return createErrorResponse(req, STATUS.BAD_REQUEST, `"${collectionName}" id does not match item.id`);
     }
     const existingIx = this.indexOf(collection, id);

--- a/src/in-memory-backend.service.ts
+++ b/src/in-memory-backend.service.ts
@@ -651,6 +651,7 @@ export class InMemoryBackendService {
     if (item.id == undefined) {
       return createErrorResponse(req, STATUS.NOT_FOUND, `Missing '${collectionName}' id`);
     }
+    // tslint:disable-next-line:triple-equals
     if (id != item.id) {
       return createErrorResponse(req, STATUS.BAD_REQUEST, `"${collectionName}" id does not match item.id`);
     }


### PR DESCRIPTION
When you add a new item using a post, it creates a new item in the collection using a number as the ID by default. However, when you update the item using a put, the default URL parser keeps the URL parameter as a string, which causes the ID matcher in the put method to fail. 