### PR TITLE
Updated the parseId to fix updating items using post and put

### DIFF
--- a/src/in-memory-backend.service.ts
+++ b/src/in-memory-backend.service.ts
@@ -539,7 +539,8 @@ export class InMemoryBackendService {
   };
 
   protected indexOf(collection: any[], id: number) {
-    return collection.findIndex((item: any) => item.id === id);
+    // tslint:disable-next-line:triple-equals
+    return collection.findIndex((item: any) => item.id == id);
   }
 
   // tries to parse id as number if collection item.id is a number.


### PR DESCRIPTION
My last fix got us halfway there. It allowed `PUT` to not fail when creating new items or updating items with string IDs, but this modifies the `parseId` to also use `==` instead of `===` such that it succeeds when updating existing elements with either `PUT` or `POST` with numeric IDs, while also preserving the ability to use string-based IDs (GUIDS, etc.).

I would have included this in the last PR but I confused a lack of error messages for a successful update from a `PUT` since I didn't have my error handler setup correctly in the tests. 