### PR TITLE
Use parseuri instead of document.createElement() for parsing url. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ examples/*.js
 examples/*.js.map
 examples/*.metadata.json
 yarn.lock
+
+!src/parseuri.d.ts

--- a/in-memory-backend.service.js
+++ b/in-memory-backend.service.js
@@ -2,6 +2,7 @@ import { Inject, Injectable, Injector, Optional } from '@angular/core';
 import { BaseResponseOptions, BrowserXhr, Headers, ReadyState, RequestMethod, Response, ResponseOptions, URLSearchParams, XHRBackend, XSRFStrategy } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/delay';
+import parseuri from 'parseuri';
 import { STATUS, STATUS_CODE_INFO } from './http-status-codes';
 ////////////  HELPERS ///////////
 /**
@@ -406,9 +407,15 @@ export var InMemoryBackendService = (function () {
         });
     };
     InMemoryBackendService.prototype.getLocation = function (href) {
-        var l = document.createElement('a');
-        l.href = href;
-        return l;
+        var uri = parseuri(href);
+        var loc = {
+            host: uri.host,
+            protocol: uri.protocol,
+            port: uri.port,
+            pathname: uri.path,
+            search: uri.query
+        };
+        return loc;
     };
     ;
     InMemoryBackendService.prototype.indexOf = function (collection, id) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "peerDependencies": {
     "@angular/core": ">=2.0.0 <5.0.0 || >=4.0.0-beta <5.0.0",
     "@angular/http": ">=2.0.0 <5.0.0 || >=4.0.0-beta <5.0.0",
-    "rxjs": "^5.0.1"
+    "rxjs": "^5.0.1",
+    "parseuri": "^0.0.5"
   },
   "devDependencies": {
     "@angular/common": "~2.4.0",

--- a/src/in-memory-backend.service.ts
+++ b/src/in-memory-backend.service.ts
@@ -8,6 +8,7 @@ import { BaseResponseOptions, BrowserXhr, Connection, ConnectionBackend,
 import { Observable } from 'rxjs/Observable';
 import { Observer }   from 'rxjs/Observer';
 import 'rxjs/add/operator/delay';
+import parseuri from 'parseuri';
 
 import { STATUS, STATUS_CODE_INFO } from './http-status-codes';
 
@@ -533,9 +534,15 @@ export class InMemoryBackendService {
   }
 
   protected getLocation(href: string) {
-    const l = document.createElement('a');
-    l.href = href;
-    return l;
+    const uri = parseuri(href);
+    const loc = {
+      host: uri.host,
+      protocol: uri.protocol,
+      port: uri.port,
+      pathname: uri.path,
+      search: uri.query
+    };
+    return loc;
   };
 
   protected indexOf(collection: any[], id: number) {

--- a/src/parseuri.d.ts
+++ b/src/parseuri.d.ts
@@ -1,0 +1,21 @@
+/*
+Module declaration for node_modules/parseuri
+*/
+declare module "parseuri" {
+    interface URI {
+        source: string;
+        protocol: string;
+        authority: string;
+        userInfo: string;
+        user: string;
+        host: string;
+        port: string;
+        path: string;
+        directory: string;
+        file: string;
+        query: string;
+        anchor: string;
+        ipv6uri: boolean;
+    }
+    export default function parseuri(url: string): URI;
+}


### PR DESCRIPTION
 This allows running on non-browser platforms, e.g. Angular Universal.

Yes, I know it seems strange to run a fake backend on a real backend, but it helps testing.