### PR TITLE
Missing url query params in angular/common/http requests

### DIFF
--- a/backend.service.js
+++ b/backend.service.js
@@ -70,7 +70,7 @@ var BackendService = (function () {
     };
     BackendService.prototype.handleRequest_ = function (req) {
         var _this = this;
-        var url = req.url;
+        var url = req.urlWithParams ? req.urlWithParams : req.url;
         // Try override parser
         // If no override parser or it returns nothing, use default parser
         var parser = this.bind('parseRequestUrl');


### PR DESCRIPTION
The request handled in backend.service.js fails to pass the url query parameters to `parseRequestUrl` when the request comes from angular/common/http which contains the parameters in `urlWithParams` variable.
```ts
    BackendService.prototype.handleRequest_ = function (req) {
        var _this = this;
        var url = req.url;
        // Try override parser
        // If no override parser or it returns nothing, use default parser
        var parser = this.bind('parseRequestUrl');
        var parsed = (parser && parser(url, this.requestInfoUtils)) ||
            this.parseRequestUrl(url);
```
Please correct me if I'm wrong, but as far as I can tell there has to be a check for urlWithParams variable in order to support url params in the Request object from both angular/http and angular/common/http.