### PR TITLE
feat: added persistence option using indexeddb

### DIFF
--- a/src/in-mem/http-backend.service.ts
+++ b/src/in-mem/http-backend.service.ts
@@ -21,6 +21,7 @@ import {
 } from './interfaces';
 
 import { BackendService } from './backend.service';
+import {InMemoryIndexedDb} from './indexed-db';
 
 /**
  * For Angular `Http` simulate the behavior of a RESTy web api
@@ -55,9 +56,10 @@ export class HttpBackendService extends BackendService implements ConnectionBack
   constructor(
     private injector: Injector,
     inMemDbService: InMemoryDbService,
+    inMemIndexedDb: InMemoryIndexedDb,
     @Inject(InMemoryBackendConfig) @Optional() config: InMemoryBackendConfigArgs
     ) {
-    super(inMemDbService, config);
+    super(inMemDbService, inMemIndexedDb, config);
   }
 
   createConnection(req: Request): Connection {

--- a/src/in-mem/http-client-backend.service.ts
+++ b/src/in-mem/http-client-backend.service.ts
@@ -22,6 +22,7 @@ import {
 } from './interfaces';
 
 import { BackendService } from './backend.service';
+import {InMemoryIndexedDb} from './indexed-db';
 
 /**
  * For Angular `HttpClient` simulate the behavior of a RESTy web api
@@ -55,10 +56,11 @@ export class HttpClientBackendService extends BackendService implements HttpBack
 
   constructor(
     inMemDbService: InMemoryDbService,
+    inMemIndexedDb: InMemoryIndexedDb,
     @Inject(InMemoryBackendConfig) @Optional() config: InMemoryBackendConfigArgs,
     private xhrFactory: XhrFactory
     ) {
-    super(inMemDbService, config);
+    super(inMemDbService, inMemIndexedDb, config);
   }
 
   handle(req: HttpRequest<any>): Observable<HttpResponse<any>> {

--- a/src/in-mem/http-client-in-memory-web-api.module.ts
+++ b/src/in-mem/http-client-in-memory-web-api.module.ts
@@ -10,15 +10,17 @@ import {
 } from './interfaces';
 
 import { HttpClientBackendService } from './http-client-backend.service';
+import {InMemoryIndexedDb, InMemoryIndexedDbImpl} from './indexed-db';
 
 // Internal - Creates the in-mem backend for the HttpClient module
 // AoT requires factory to be exported
 export function httpClientInMemBackendServiceFactory(
   dbService: InMemoryDbService,
+  indexedDb: InMemoryIndexedDb,
   options: InMemoryBackendConfig,
   xhrFactory: XhrFactory,
 ): HttpBackend {
-  const backend: any = new HttpClientBackendService(dbService, options, xhrFactory);
+  const backend: any = new HttpClientBackendService(dbService, indexedDb, options, xhrFactory);
   return backend;
 }
 
@@ -45,10 +47,10 @@ export class HttpClientInMemoryWebApiModule {
       providers: [
         { provide: InMemoryDbService,  useClass: dbCreator },
         { provide: InMemoryBackendConfig, useValue: options },
-
+        { provide: InMemoryIndexedDb, useClass: InMemoryIndexedDbImpl },
         { provide: HttpBackend,
           useFactory: httpClientInMemBackendServiceFactory,
-          deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory]}
+          deps: [InMemoryDbService, InMemoryIndexedDb, InMemoryBackendConfig, XhrFactory]}
       ]
     };
   }

--- a/src/in-mem/http-in-memory-web-api.module.ts
+++ b/src/in-mem/http-in-memory-web-api.module.ts
@@ -10,15 +10,17 @@ import {
 } from './interfaces';
 
 import { HttpBackendService }       from './http-backend.service';
+import {InMemoryIndexedDb, InMemoryIndexedDbImpl} from './indexed-db';
 
 // Internal - Creates the in-mem backend for the Http module
 // AoT requires factory to be exported
 export function httpInMemBackendServiceFactory(
   injector: Injector,
   dbService: InMemoryDbService,
+  indexedDb: InMemoryIndexedDb,
   options: InMemoryBackendConfig
 ): XHRBackend {
-  const backend: any = new HttpBackendService(injector, dbService, options);
+  const backend: any = new HttpBackendService(injector, dbService, indexedDb, options);
   return backend as XHRBackend;
 }
 
@@ -45,10 +47,10 @@ export class HttpInMemoryWebApiModule {
       providers: [
         { provide: InMemoryDbService,  useClass: dbCreator },
         { provide: InMemoryBackendConfig, useValue: options },
-
+        { provide: InMemoryIndexedDb, useClass: InMemoryIndexedDbImpl },
         { provide: XHRBackend,
           useFactory: httpInMemBackendServiceFactory,
-          deps: [Injector, InMemoryDbService, InMemoryBackendConfig]}
+          deps: [Injector, InMemoryDbService, InMemoryIndexedDb, InMemoryBackendConfig]}
       ]
     };
   }

--- a/src/in-mem/indexed-db.spec.ts
+++ b/src/in-mem/indexed-db.spec.ts
@@ -1,0 +1,84 @@
+import {IndexedDB} from './indexed-db';
+import {switchMap} from 'rxjs/operators';
+
+describe('IndexedDB', () => {
+  let indexedDB: IndexedDB;
+  beforeEach(() => {
+    indexedDB = new IndexedDB('testDatabase');
+  });
+
+  afterEach((done) => {
+    indexedDB
+      .closeDatabase()
+      .pipe(
+        switchMap((databaseName: string) => IndexedDB.deleteDatabase(databaseName))
+      )
+      .subscribe(() => done(), () => done());
+  });
+
+  it('should create new database', (done) => {
+    indexedDB.getDatabase()
+      .subscribe(
+        (data) => done()
+      );
+    expect(indexedDB).toBeDefined();
+  });
+
+  it('should store and retrieve simple collections', (done) => {
+    indexedDB
+      .storeCollections({items: [1, 2, 3, 4, 5]})
+      .pipe(
+        switchMap(() => indexedDB.getCollections())
+      )
+      .subscribe((data) => {
+        expect(data).toEqual({items: [1, 2, 3, 4, 5]});
+        done();
+      });
+  });
+
+  it('should store and retrieve complex collections', (done) => {
+    const users = [
+      {id: 1, name: 'Test User'}
+    ];
+
+    const projects = [
+      {id: 1, title: 'My first project',
+        description: 'This is your first project.', comments: <any>[]},
+      {id: 2, title: 'My second project',
+        description: 'This is your second project.', comments: [
+        {id: 1, content: 'This is a comment'}
+      ]}
+    ];
+
+    const tasks = [
+      {id: 1, projectId: 1, title: 'Task 1', done: false},
+      {id: 2, projectId: 1, title: 'Task 2', done: false},
+      {id: 3, projectId: 1, title: 'Task 3', done: true},
+      {id: 4, projectId: 2, title: 'Task 4', done: false}
+    ];
+
+    const collections = {users, projects, tasks};
+
+    indexedDB
+      .storeCollections(collections)
+      .pipe(
+        switchMap(() => indexedDB.getCollections())
+      )
+      .subscribe((data) => {
+        expect(data).toEqual(collections);
+        done();
+      });
+  });
+
+  it('should clear collection', (done) => {
+    indexedDB
+      .storeCollections({data: 'Test'})
+      .pipe(
+        switchMap(() => indexedDB.clearCollections())
+      )
+      .subscribe((data) => {
+        expect(data).toBeUndefined();
+        done();
+      });
+  });
+});

--- a/src/in-mem/indexed-db.spec.ts
+++ b/src/in-mem/indexed-db.spec.ts
@@ -1,34 +1,37 @@
-import {IndexedDB} from './indexed-db';
-import {switchMap} from 'rxjs/operators';
+import { InMemoryIndexedDb, InMemoryIndexedDbImpl } from './indexed-db';
+import { switchMap } from 'rxjs/operators';
 
-describe('IndexedDB', () => {
-  let indexedDB: IndexedDB;
+describe('InMemoryIndexedDb', () => {
+  let indexedDb: InMemoryIndexedDb;
   beforeEach(() => {
-    indexedDB = new IndexedDB('testDatabase');
+    indexedDb = new InMemoryIndexedDbImpl({
+      persistence: true,
+      persistenceDatabase: 'testDatabase'
+    });
   });
 
   afterEach((done) => {
-    indexedDB
+    indexedDb
       .closeDatabase()
       .pipe(
-        switchMap((databaseName: string) => IndexedDB.deleteDatabase(databaseName))
+        switchMap((databaseName: string) => InMemoryIndexedDb.deleteDatabase(databaseName))
       )
       .subscribe(() => done(), () => done());
   });
 
   it('should create new database', (done) => {
-    indexedDB.getDatabase()
+    indexedDb.getDatabase()
       .subscribe(
         (data) => done()
       );
-    expect(indexedDB).toBeDefined();
+    expect(indexedDb).toBeDefined();
   });
 
   it('should store and retrieve simple collections', (done) => {
-    indexedDB
+    indexedDb
       .storeCollections({items: [1, 2, 3, 4, 5]})
       .pipe(
-        switchMap(() => indexedDB.getCollections())
+        switchMap(() => indexedDb.getCollections())
       )
       .subscribe((data) => {
         expect(data).toEqual({items: [1, 2, 3, 4, 5]});
@@ -59,10 +62,10 @@ describe('IndexedDB', () => {
 
     const collections = {users, projects, tasks};
 
-    indexedDB
+    indexedDb
       .storeCollections(collections)
       .pipe(
-        switchMap(() => indexedDB.getCollections())
+        switchMap(() => indexedDb.getCollections())
       )
       .subscribe((data) => {
         expect(data).toEqual(collections);
@@ -71,10 +74,10 @@ describe('IndexedDB', () => {
   });
 
   it('should clear collection', (done) => {
-    indexedDB
+    indexedDb
       .storeCollections({data: 'Test'})
       .pipe(
-        switchMap(() => indexedDB.clearCollections())
+        switchMap(() => indexedDb.clearCollections())
       )
       .subscribe((data) => {
         expect(data).toBeUndefined();

--- a/src/in-mem/indexed-db.ts
+++ b/src/in-mem/indexed-db.ts
@@ -1,0 +1,129 @@
+import {ReplaySubject} from 'rxjs/ReplaySubject';
+import {Observable} from 'rxjs/Observable';
+import {map, switchMap, take, tap} from 'rxjs/operators';
+import {Observer} from 'rxjs/Observer';
+
+const COLLECTIONS_KEY = 1;
+const COLLECTIONS_OBJECT_STORE = 'collections';
+
+const emitError = (observable: Observer<any>, event: any) =>
+  observable.error(`IndexedDB Error: ${event.target.error}`);
+const emitResult = (observable: Observer<any>, event: any) =>
+  observable.next(event.target.result);
+
+export class IndexedDB {
+  static indexedDB: IDBFactory = window.indexedDB || window['mozIndexedDB'] || window['webkitIndexedDB'] || window['msIndexedDB'];
+
+  private database$ = new ReplaySubject<IDBDatabase>(1);
+
+  static deleteDatabase(databaseName: string) {
+    return new Observable<any>((observer: Observer<any>) => {
+      const request = IndexedDB.indexedDB
+        .deleteDatabase(databaseName);
+      request.addEventListener('success', (event) => emitResult(observer, event));
+      request.addEventListener('error', (event) => emitError(observer, event));
+    });
+  }
+
+  constructor(private databaseName: string) {
+    this.createOrOpenDatabase();
+  }
+
+  createOrOpenDatabase() {
+    const request = IndexedDB.indexedDB.open(this.databaseName, 1);
+    request.addEventListener('success',
+      (event) => this.database$.next((<any>event.target).result)
+    );
+    request.addEventListener('error', (event) => emitError(this.database$, event));
+    request.addEventListener('upgradeneeded',
+      (event) => {
+        const database: IDBDatabase = (<any>event.target).result;
+        database.createObjectStore(COLLECTIONS_OBJECT_STORE);
+        database.addEventListener('error', (e) => emitError(this.database$, e));
+      }
+    );
+  }
+
+  closeDatabase(): Observable<string> {
+    return this.database$
+      .asObservable()
+      .pipe(
+        take(1),
+        map((database: IDBDatabase) => {
+          database.close();
+          return this.databaseName;
+        })
+      );
+  }
+
+  getDatabase(): Observable<IDBDatabase> {
+    return this.database$.asObservable();
+  }
+
+  getCollections(): Observable<any> {
+    return this.database$
+      .asObservable()
+      .pipe(
+        take(1),
+        switchMap((database: IDBDatabase) => {
+          return new Observable((observer: Observer<any>) => {
+            const transaction = database.transaction(COLLECTIONS_OBJECT_STORE, 'readwrite');
+            transaction.addEventListener('error', (event) => emitError(observer, event));
+
+            const request = transaction.objectStore(COLLECTIONS_OBJECT_STORE).get(COLLECTIONS_KEY);
+            request.addEventListener('error', (event) => emitError(observer, event));
+            request.addEventListener('success', (event) => emitResult(observer, event));
+          });
+        })
+      );
+  }
+
+  storeCollections(collections: any): Observable<any> {
+    return this.database$
+      .asObservable()
+      .pipe(
+        take(1),
+        switchMap((database: IDBDatabase) => {
+          return new Observable((observer: Observer<any>) => {
+            const transaction = database.transaction(COLLECTIONS_OBJECT_STORE, 'readwrite');
+            transaction.addEventListener('error', (event) => emitError(observer, event));
+
+            const clearRequest = transaction
+              .objectStore(COLLECTIONS_OBJECT_STORE)
+              .clear();
+
+            clearRequest.addEventListener('error', (event) => emitError(observer, event));
+            clearRequest.addEventListener('success', () => {
+              const addRequest = transaction
+                .objectStore(COLLECTIONS_OBJECT_STORE)
+                .add(collections, COLLECTIONS_KEY);
+
+              addRequest.addEventListener('error', (event) => emitError(observer, event));
+              addRequest.addEventListener('success', (event) => emitResult(observer, event));
+            });
+          });
+        })
+      );
+  }
+
+  clearCollections(): Observable<any> {
+    return this.database$
+      .asObservable()
+      .pipe(
+        take(1),
+        switchMap((database: IDBDatabase) => {
+          return new Observable((observer: Observer<any>) => {
+            const transaction = database.transaction(COLLECTIONS_OBJECT_STORE, 'readwrite');
+            transaction.addEventListener('error', (event) => emitError(observer, event));
+
+            const clearRequest = transaction
+              .objectStore(COLLECTIONS_OBJECT_STORE)
+              .clear();
+
+            clearRequest.addEventListener('error', (event) => emitError(observer, event));
+            clearRequest.addEventListener('success', (event) => emitResult(observer, event));
+          });
+        })
+      );
+  }
+}

--- a/src/in-mem/interfaces.ts
+++ b/src/in-mem/interfaces.ts
@@ -60,6 +60,15 @@ export abstract class InMemoryBackendConfigArgs {
    */
   delay?: number;
   /**
+   * false (default) will not persist any data and a browser reload will re-run the `createDb` function in your database services.
+   * true: Data will be persisted to a indexedDB database in your browser.
+   */
+  persistence?: boolean;
+  /**
+   * the indexedDB database name when using the persistence feature.
+   */
+  persistenceDatabase?: string;
+  /**
    * false (default) should 204 when object-to-delete not found; true: 404
    */
   delete404?: boolean;
@@ -110,6 +119,8 @@ export class InMemoryBackendConfig implements InMemoryBackendConfigArgs {
       caseSensitiveSearch: false,
       dataEncapsulation: false, // do NOT wrap content within an object with a `data` property
       delay: 500, // simulate latency by delaying response
+      persistence: false, // use indexedDB to persist data
+      persistenceDatabase: 'ngInMemoryWebApi', // database name when using persistence
       delete404: false, // don't complain if can't find entity to delete
       passThruUnknownUrl: false, // 404 if can't process URL
       post204: true, // don't return the item after a POST


### PR DESCRIPTION
This fixes #158 and adds a feature to persist data across multiple browser sessions using IndexedDB to store the in-memory database. Let's discuss the changes and if everything is fine, i'll add more tests and documentation.