### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ CLI-based apps can exclude the provider in production builds like this:
   imports: [
     HttpClientModule,
     environment.production ?
-      HttpClientInMemoryWebApiModule.forRoot(InMemHeroService) : []
+      [] : HttpClientInMemoryWebApiModule.forRoot(InMemHeroService)
     ...
   ]
   ```


### PR DESCRIPTION
I am guessing if we are running production version, we shouldn't be using HttpClientInMemoryWebApiModule.forRoot(InMemHeroService)? Unless I am not understanding this correctly.