### PR TITLE
feat: allow objects with no ids to be added to an empty collection

### DIFF
--- a/src/in-mem/backend.service.ts
+++ b/src/in-mem/backend.service.ts
@@ -406,7 +406,7 @@ export abstract class BackendService {
    * @param collectionName - name of the collection
    */
   protected genIdDefault<T extends { id: any }>(collection: T[], collectionName: string): any {
-    if (!this.isCollectionIdNumeric(collection, collectionName)) {
+    if (this.isNotEmpty(collection) && !this.isCollectionIdNumeric(collection, collectionName)) {
       throw new Error(
         `Collection '${collectionName}' id type is non-numeric or unknown. Can only generate numeric ids.`);
     }
@@ -513,7 +513,11 @@ export abstract class BackendService {
   protected isCollectionIdNumeric<T extends { id: any }>(collection: T[], collectionName: string): boolean {
     // collectionName not used now but override might maintain collection type information
     // so that it could know the type of the `id` even when the collection is empty.
-    return !!(collection && collection[0]) && typeof collection[0].id === 'number';
+    return this.isNotEmpty(collection) && typeof collection[0].id === 'number';
+  }
+
+  protected isNotEmpty<T extends { id: any }>(collection: T[]): boolean {
+    return !!(collection && collection[0]);
   }
 
   /**

--- a/src/in-mem/http-backend.service.spec.ts
+++ b/src/in-mem/http-backend.service.spec.ts
@@ -232,12 +232,26 @@ describe('Http Backend Service', () => {
         );
     }));
 
-    it('should fail when add a nobody without an id to empty nobodies collection', async(() => {
+    it('can add a nobody without an id to empty nobodies collection', async(() => {
       http.post('api/nobodies', { name: 'Noman' })
+        .concatMap(() => http.get('api/nobodies'))
+        .map(res => res.json())
         .subscribe(
+          nobodies => {
+            expect(nobodies.length).toBe(1, 'should a nobody');
+            expect(nobodies[0].name).toBe('Noman', 'should be "Noman"');
+            expect(nobodies[0].id).toBeDefined();
+          },
+          failure
+        );
+    }));
+
+    it('should fail when we add a hero with no id to stringers', async(() => {
+      http.post('api/stringers', { name: 'Stringer'})
+      .subscribe(
         _ => {
           console.log(_);
-          fail(`should not have been able to add 'Norman' to 'nobodies'`);
+          fail(`should not have been able to add 'Stringer' to 'stringers'`);
         },
         err => {
           expect(err.status).toBe(422, 'should have 422 status');

--- a/src/in-mem/http-client-backend.service.spec.ts
+++ b/src/in-mem/http-client-backend.service.spec.ts
@@ -270,12 +270,25 @@ describe('HttpClient Backend Service', () => {
         );
     }));
 
-    it('should fail when add a nobody without an id to empty nobodies collection', async(() => {
-      http.post('api/nobodies', { name: 'Noman' })
+    it('can add a nobody without an id to an empty nobodies collection', async(() => {
+      http.post('api/nobodies', { name: 'Noman'})
+        .concatMap(() => http.get<Nobody[]>('api/nobodies'))
         .subscribe(
+          nobodies => {
+            expect(nobodies.length).toBe(1, 'should a nobody');
+            expect(nobodies[0].name).toBe('Noman', 'should be "Noman"');
+            expect(nobodies[0].id).toBeDefined();
+          },
+          failure
+        );
+    }));
+
+    it('should fail when we add a hero with no id to stringers', async(() => {
+      http.post('api/stringers', { name: 'Stringer'})
+      .subscribe(
         _ => {
           console.log(_);
-          fail(`should not have been able to add 'Norman' to 'nobodies'`);
+          fail(`should not have been able to add 'Stringer' to 'stringers'`);
         },
         err => {
           expect(err.status).toBe(422, 'should have 422 status');
@@ -660,4 +673,3 @@ describe('HttpClient Backend Service', () => {
 
   });
 });
-


### PR DESCRIPTION
Whilst issues caused by the current functionality, https://github.com/angular/angular/issues/22623 or #162 for example, can be solved through the use of a custom `genId` it strikes me that most developers who use _in-memory-web-api_ will:

1. Be sufficiently experienced or dealing with a level of complexity from the start that they already generate IDs using `genId`
2. Have made the conscious decision to allow _in-memory-web-api_ to generate their IDs
3. Be inexperienced enough (in the case of the tutorial followers especially) that it causes unexpected issues which in turn breaks their flow as they chase down a fix

In the case of **1** this PR changes nothing and in the cases of **2** and **3** it improves the functionality and developer experience.