### PR TITLE
fix: check if 'location' exists on Document object

### DIFF
--- a/src/in-mem/backend.service.ts
+++ b/src/in-mem/backend.service.ts
@@ -438,10 +438,11 @@ export abstract class BackendService {
    */
   protected getLocation(url: string): UriInfo {
     if (!url.startsWith('http')) {
-      // get the document iff running in browser
+      // get the document if running in browser
       const doc: Document = (typeof document === 'undefined') ? undefined : document;
       // add host info to url before parsing.  Use a fake host when not in browser.
-      const base = doc ? doc.location.protocol + '//' + doc.location.host : 'http://fake';
+      const { location } = doc;
+      const base = location ? location.protocol + '//' + location.host : 'http://fake';
       url = url.startsWith('/') ? base + url : base + '/' + url;
     }
     return parseUri(url);


### PR DESCRIPTION
NativeScript has a fake global 'document' object, which doesn't
have a 'location' property. This PR introduces a check that the
'location' property is defined before retrieving it and allows the
package to be used with NativeScript.

related to https://github.com/angular/angular/issues/22093